### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   cicd73:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
+      - image: wunderio/silta-cicd:circleci-php7.3-node12-composer1-v0.1
 
 workflows:
   version: 2

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
-FROM wunderio/drupal-nginx:v0.1
+FROM wunderio/silta-nginx:v0.1
 
 COPY . /app/web
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-php-fpm:v0.1
+FROM wunderio/silta-php-fpm:v0.1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-shell:v0.1
+FROM wunderio/silta-php-shell:v0.1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.